### PR TITLE
Fix bash prompt cursor issue and add systematic thinking rules

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -34,7 +34,7 @@ if [ -x "$(command -v brew)" ]; then
 
     ## bash-completion
 
-    [ -e "${BREW_PREFIX}/etc/bash_completion"          ] && . ${BREW_PREFIX}/etc/bash_completion
+    [[ -r "${BREW_PREFIX}/etc/profile.d/bash_completion.sh" ]] && . "${BREW_PREFIX}/etc/profile.d/bash_completion.sh"
 
     ## android sdk & ndk
 
@@ -83,16 +83,10 @@ if [ -x "$(command -v brew)" ]; then
     [ -s "${BREW_PREFIX}/opt/nvm/nvm.sh"               ] && . "${BREW_PREFIX}/opt/nvm/nvm.sh"
     [ -s "${BREW_PREFIX}/opt/nvm/etc/bash_completion"  ] && . "${BREW_PREFIX}/opt/nvm/etc/bash_completion"
 
-    ## bash-git-prompt
-    if [ -f "${BREW_PREFIX}/opt/bash-git-prompt/share/gitprompt.sh" ]; then
-        __GIT_PROMPT_DIR="${BREW_PREFIX}/opt/bash-git-prompt/share"
-        source "${BREW_PREFIX}/opt/bash-git-prompt/share/gitprompt.sh"
-    fi
 fi
 
-## git command line promption
-
-[ ! -z "$(command -v __git_ps1)" ] && export PROMPT_COMMAND='__git_ps1 "\\[$(tput bold)\\]\u@\h\\[$(tput sgr0)\\]:\\[$(tput setaf 4)\\]\w\\[$(tput sgr0)\\]" " \\\$ "'
+## git command line prompt
+[ -n "$(command -v __git_ps1)" ] && PS1='\[\e[1m\]\u@\h\[\e[0m\]:\[\e[34m\]\w\[\e[0m\]$(__git_ps1 " (%s)") \$ '
 
 ## user bins
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,6 +29,17 @@ Correct:
 Agent(subagent_type="worker", prompt="...", run_in_background=true)  ← ALWAYS
 ```
 
+## Systematic Thinking Before Execution
+
+Before dispatching any work, **stop and think systematically**:
+
+- **Intent over literal words** -- understand what the user actually means, not just the surface-level string they typed. A request to change one thing often implies changing everything conceptually related to it.
+- **Completeness** -- trace all downstream dependencies: code, types, config, tests, docs, comments, error messages, examples. If you change A, find everything that references or depends on A.
+- **Consistency** -- after a change, the entire codebase should tell one coherent story. No stale references, no contradictions between files, no half-done renames.
+- **Validate against the user's mental model** -- a passing build proves compilation, not correctness. Ask: "if the user reviews this diff, would they consider the job done?"
+
+**Checkpoint**: Before dispatching any worker, explicitly list all affected locations in your response first. This makes the thinking visible and reviewable — if something is missing, the user can catch it before execution begins.
+
 ## Git PR Rules
 
 - Each PR must contain exactly **1 commit**


### PR DESCRIPTION
## Summary
- Replace `PROMPT_COMMAND` (`__git_ps1`) with direct PS1 embedding `$(__git_ps1 " (%s)")` to fix readline width miscalculation on long commands and narrow terminals
- Disable `bash-git-prompt` to avoid `PROMPT_COMMAND` conflicts
- Update bash-completion sourcing to `bash-completion@2` style
- Add systematic thinking guidelines to `CLAUDE.md`

## Test plan
- [x] Open new terminal, verify git branch/status shows in prompt
- [x] Type a long command that wraps — cursor should stay aligned
- [x] Resize terminal to narrow width, press up arrow — no cursor corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)