### PR TITLE
Add Claude Code settings with hooks configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "skipDangerousModePermissionPrompt": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "say 'Construction in progress.'"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "say 'Good day, commander. I am here!'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "say \"$(cat /dev/stdin | jq -r '.last_assistant_message' | head -1)\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add .claude/settings.json with dangerous mode permission skip and TTS hooks
- Hooks:
  - PreToolUse: say Construction in progress before each tool call
  - Notification (idle_prompt): say Good day, commander. I am here! when idle > 60s
  - Stop: read and speak the first line of Claude last assistant message via TTS

## Test plan
- [ ] Verify PreToolUse hook triggers before tool calls
- [ ] Verify Notification hook triggers only on idle prompt
- [ ] Verify Stop hook reads and speaks the first line of the last assistant message

Generated with [Claude Code](https://claude.com/claude-code)